### PR TITLE
No dicetricks

### DIFF
--- a/Charms.tex
+++ b/Charms.tex
@@ -52,7 +52,7 @@
   {3m}
   {Supplemental}{Instant}{-}
   {Archery 4, Sight Without Eyes}
-  This charm supplements a withering Archery attack from short or close range. If the attack does at least as one damage as her target's Stamina, that Initiative is lost rather than transferred to the Solar, and the target is knocked down and back an entire range band.
+  This charm supplements a withering Archery attack from short or close range. If the attack does at least as much damage as her target's Stamina, that Initiative is lost rather than transferred to the Solar, and the target is knocked down and back an entire range band.
 
   \charm{There Is No Wind}
   {3m}

--- a/Rewrite.tex
+++ b/Rewrite.tex
@@ -474,7 +474,7 @@ The Exalted are mighty. Some break swords upon their skin or shatter stone with 
 \subsection*{Minimums}
 \par Solar charms all require a minimum level of skill in their associated ability, and many of them expand on earlier charms in that ability. A character must meet all of a charm's Prereqs before she can learn it. Some charms offer also repurchases - by buying a charm additional times, a character can unlock further power.
 
-\par Charms in your Supernal Abilities treat your Essence rating 2 higher than your current rating (to a maximum of 5) for all purposes. You can learn Essence 3 charms in these abilities right off the bat during character creation, and use upgrades to them sooner than otherwise. When your character's essence is 4, then a charm in one of your Supernal Abilities that lets you make (Essence + 2) attacks allows you to make 5 (your real Essence 4 + 2, to a maximum of 5).
+\par A Solar treats her Essence as 2 higher for charms in her Supernal Abilities (to a maximum of 5) for all purposes. She can learn Essence 3 charms in these abilities at character creation, and use upgrades to them sooner than otherwise. When Solar's  essence is 4, then a charm in one of her Supernal Abilities that lets her make (Essence + 2) attacks allows her to make 5 (her real Essence 4 + 2, to a maximum of 5).
 
 \subsection*{Costs}
 \par Most charms have a cost - they require an exertion of motes, willpower, initiative or even health levels. A character must pay the full cost before activating a charm - they cannot spend their initiative below 0, for example.

--- a/Rewrite.tex
+++ b/Rewrite.tex
@@ -474,7 +474,7 @@ The Exalted are mighty. Some break swords upon their skin or shatter stone with 
 \subsection*{Minimums}
 \par Solar charms all require a minimum level of skill in their associated ability, and many of them expand on earlier charms in that ability. A character must meet all of a charm's Prereqs before she can learn it. Some charms offer also repurchases - by buying a charm additional times, a character can unlock further power.
 
-\par A Solar treats her Essence as 5 for charms in her Supernal Ability for the purposes of prerequistes, upgrades and accessing repurchases, but not for calculating numeric effects (such as range or number of successes added).
+\par Charms in your Supernal Abilities treat your Essence rating 2 higher than your current rating (to a maximum of 5) for all purposes. You can learn Essence 3 charms in these abilities right off the bat during character creation, and use upgrades to them sooner than otherwise. When your character's essence is 4, then a charm in one of your Supernal Abilities that lets you make (Essence + 2) attacks allows you to make 5 (your real Essence 4 + 2, to a maximum of 5).
 
 \subsection*{Costs}
 \par Most charms have a cost - they require an exertion of motes, willpower, initiative or even health levels. A character must pay the full cost before activating a charm - they cannot spend their initiative below 0, for example.


### PR DESCRIPTION
Small typo in Force without Fire fixed and matched description of Supernals in "Reading Charms" section to match description from Char gen. Still had the old description of counting as Essence 5 for purposes of learning, but not for any calculations used in the charm itself.